### PR TITLE
Add authenticated user lookup route

### DIFF
--- a/src/main/scala/com/iscs/ratingbunny/Server.scala
+++ b/src/main/scala/com/iscs/ratingbunny/Server.scala
@@ -117,7 +117,8 @@ object Server:
             EmailContactRoutes.httpRoutes(emailSvc) <+>
             ImdbRoutes.publicRoutes(imdbSvc, historyRepo) <+>
             PoolSvcRoutes.httpRoutes(poolSvc) <+>
-            AuthRoutes.httpRoutes(authSvc, loginSvc, userRepo, token)),
+            AuthRoutes.httpRoutes(authSvc, loginSvc, userRepo, token) <+>
+            AuthRoutes.authedRoutes(userRepo, authMw)),
         s"/api/$apiVersion/pro" ->
           ImdbRoutes.authedRoutes(imdbSvc, historyRepo, authMw)
       ).orNotFound

--- a/src/main/scala/com/iscs/ratingbunny/domains/package.scala
+++ b/src/main/scala/com/iscs/ratingbunny/domains/package.scala
@@ -99,6 +99,9 @@ package object domains:
   final case class LoginOK(userid: String, tokens: TokenPair)
   final case class SignupOK(userid: String, tokens: TokenPair)
 
+  /** Public view of a user, omitting sensitive fields */
+  final case class UserInfo(userid: String, email: String, displayName: Option[String])
+
   // ===== Requests / responses ===================================================
   final case class RegisterReq(email: String, password: String)
   final case class LoginReq(email: String, password: String)


### PR DESCRIPTION
## Summary
- expose public `UserInfo` view for users
- add authenticated `/auth/me` route
- wire new route into server and test it

## Testing
- `sbt test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689aa406e7d08332b3cd97af010e2632