### PR TITLE
Decode JWT for public routes logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Working Scala REST backend to allow retrieval of movie info and posters.
 
+Even requests to the free endpoints should include an `Authorization: Bearer <token>`
+header so activity can be attributed to a user. Calls without a valid token are
+still served but the requester will be logged as `guest`.
+
 ### Running locally
 
 Environment variables required by the service can be stored in a `.env` file at

--- a/src/main/scala/com/iscs/ratingbunny/Server.scala
+++ b/src/main/scala/com/iscs/ratingbunny/Server.scala
@@ -115,7 +115,7 @@ object Server:
         s"/api/$apiVersion" ->
           (FetchImageRoutes.httpRoutes(fetchSvc) <+>
             EmailContactRoutes.httpRoutes(emailSvc) <+>
-            ImdbRoutes.publicRoutes(imdbSvc, historyRepo) <+>
+              ImdbRoutes.publicRoutes(imdbSvc, historyRepo, jwtSecretKey) <+>
             PoolSvcRoutes.httpRoutes(poolSvc) <+>
             AuthRoutes.httpRoutes(authSvc, loginSvc, userRepo, token) <+>
             AuthRoutes.authedRoutes(userRepo, authMw)),


### PR DESCRIPTION
## Summary
- log public route requests with user ID from Authorization header
- expose JwtAuth helpers for decoding user tokens
- document default `guest` logging when token missing

## Testing
- `sbt test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689fe3939648833289ada5536e950ba2