### PR TITLE
Add email verification to signup flow

### DIFF
--- a/src/main/scala/com/iscs/ratingbunny/domains/package.scala
+++ b/src/main/scala/com/iscs/ratingbunny/domains/package.scala
@@ -84,7 +84,10 @@ package object domains:
       status: SubscriptionStatus,
       displayName: Option[String],
       prefs: List[String] = Nil,
-      createdAt: Instant = Instant.now()
+      createdAt: Instant = Instant.now(),
+      emailVerified: Boolean = false,
+      verificationTokenHash: Option[String] = None,
+      verificationExpires: Option[Instant] = None // consider cron to clean up expired tokens
   )
 
   final case class UserProfileDoc(
@@ -97,7 +100,7 @@ package object domains:
   // ---------- request / response ----------
   final case class LoginRequest(email: String, password: String)
   final case class LoginOK(userid: String, tokens: TokenPair)
-  final case class SignupOK(userid: String, tokens: TokenPair)
+  final case class SignupOK(userid: String)
 
   /** Public view of a user, omitting sensitive fields */
   final case class UserInfo(userid: String, email: String, plan: String, displayName: Option[String])

--- a/src/main/scala/com/iscs/ratingbunny/routes/AuthRoutes.scala
+++ b/src/main/scala/com/iscs/ratingbunny/routes/AuthRoutes.scala
@@ -69,8 +69,8 @@ object AuthRoutes:
                   case Right(ok) =>
                     Created(
                       Json.obj(
-                        "access"  -> ok.tokens.access.asJson,
-                        "refresh" -> ok.tokens.refresh.asJson
+                        "userid"  -> ok.userid.asJson,
+                        "message" -> "verification email sent".asJson
                       )
                     )
                   case Left(EmailExists)  => Conflict("email exists")


### PR DESCRIPTION
## Summary
- extend UserDoc for email verification token and flag
- generate and email verification token during signup
- update signup route and server wiring for verification workflow

## Testing
- `sbt test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7016241c8332bf82689fd04676a9