### PR TITLE
Ensure normalized email stored under snake case field

### DIFF
--- a/src/main/scala/com/iscs/ratingbunny/domains/AuthLogin.scala
+++ b/src/main/scala/com/iscs/ratingbunny/domains/AuthLogin.scala
@@ -22,7 +22,7 @@ final class AuthLoginImpl[F[_]: Async](
     val emailNorm = req.email.trim.toLowerCase
     for
       userOpt <- usersCol
-        .find(feq("emailNorm", emailNorm))
+        .find(feq("email_norm", emailNorm))
         .first
 
       result <- userOpt match

--- a/src/main/scala/com/iscs/ratingbunny/domains/package.scala
+++ b/src/main/scala/com/iscs/ratingbunny/domains/package.scala
@@ -2,6 +2,7 @@ package com.iscs.ratingbunny
 
 import com.iscs.ratingbunny.model.Requests.ReqParams
 import mongo4cats.bson.ObjectId
+import org.mongodb.scala.bson.annotations.BsonProperty
 
 import java.time.Instant
 
@@ -78,7 +79,7 @@ package object domains:
   final case class UserDoc(
       _id: ObjectId = new ObjectId(),
       email: String,
-      emailNorm: String,
+      @BsonProperty("email_norm") emailNorm: String,
       passwordHash: String,
       userid: String,
       plan: Plan,


### PR DESCRIPTION
## Summary
- Map `emailNorm` field to MongoDB's `email_norm` using `@BsonProperty`
- Query for normalized emails with `email_norm` field during login

## Testing
- `sbt test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
- `apt-get install -y sbt` *(fails: Unable to locate package sbt)*

------
https://chatgpt.com/codex/tasks/task_e_68be505798888332a149e608da012a90