### PR TITLE
Log signup errors in AuthCheck

### DIFF
--- a/src/main/scala/com/iscs/ratingbunny/domains/AuthCheck.scala
+++ b/src/main/scala/com/iscs/ratingbunny/domains/AuthCheck.scala
@@ -103,5 +103,6 @@ final class AuthCheckImpl[F[_]: Async](
             if mw.getError.getCode == docFail ||
               mw.getError.getMessage.startsWith("Document failed validation") =>
           Left(SignupError.InvalidEmail)
-        case _ =>
+        case e =>
+          L.error("Error during signup", e)
           Left(SignupError.BadPassword) // or a generic failure


### PR DESCRIPTION
## Summary
- log details for unexpected errors in AuthCheck signup to aid debugging

## Testing
- `sbt test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be5d6fdc888332bae9ab451ced47f3