### PR TITLE
Use verify method for email token validation

### DIFF
--- a/src/main/scala/com/iscs/ratingbunny/Server.scala
+++ b/src/main/scala/com/iscs/ratingbunny/Server.scala
@@ -84,7 +84,9 @@ object Server:
 
   private def getUserRepoSvc[F[_]: Async](db: MongoDatabase[F]): F[UserRepo[F]] =
     for userCollCodec <- db.getCollectionWithCodec[UserDoc](usersCollection)
-    yield new UserRepoImpl(userCollCodec)
+    yield
+      val hasher = BcryptHasher.make[F](cost = 12)
+      new UserRepoImpl(userCollCodec, hasher)
 
   private def getTokenIssuerSvc[F[_]: Async](
       redis: RedisCommands[F, String, String],

--- a/src/main/scala/com/iscs/ratingbunny/domains/UserRepo.scala
+++ b/src/main/scala/com/iscs/ratingbunny/domains/UserRepo.scala
@@ -5,20 +5,35 @@ import cats.implicits.*
 import mongo4cats.circe.*
 import mongo4cats.collection.MongoCollection
 import org.mongodb.scala.model.{Updates as JUpdates}
+import com.iscs.ratingbunny.util.PasswordHasher
 
 trait UserRepo[F[_]]:
   def findByEmail(email: String): F[Option[UserDoc]]
   def insert(u: UserDoc): F[Unit]
   def findByUserId(id: String): F[Option[UserDoc]]
-  def findByVerificationTokenHash(hash: String): F[Option[UserDoc]]
+  def findByVerificationToken(token: String): F[Option[UserDoc]]
   def markEmailVerified(uid: String): F[Unit]
 
-class UserRepoImpl[F[_]: Async](collection: MongoCollection[F, UserDoc]) extends UserRepo[F] with QuerySetup:
+class UserRepoImpl[F[_]: Async](collection: MongoCollection[F, UserDoc], hasher: PasswordHasher[F])
+    extends UserRepo[F]
+    with QuerySetup:
   override def findByEmail(email: String): F[Option[UserDoc]] = collection.find(feq("email", email)).first
   override def insert(u: UserDoc): F[Unit]                    = collection.insertOne(u).void
   override def findByUserId(uid: String): F[Option[UserDoc]]  = collection.find(feq("userid", uid)).first
-  override def findByVerificationTokenHash(hash: String): F[Option[UserDoc]] =
-    collection.find(feq("verificationTokenHash", hash)).first
+
+  override def findByVerificationToken(token: String): F[Option[UserDoc]] =
+    collection
+      .find
+      .stream
+      .evalMap: u =>
+        u.verificationTokenHash match
+          case Some(h) => hasher.verify(token, h).map(res => if res then Some(u) else None)
+          case None    => Async[F].pure(None)
+      .collect { case Some(u) => u }
+      .head
+      .compile
+      .last
+
   override def markEmailVerified(uid: String): F[Unit] =
     val update = JUpdates.combine(
       JUpdates.set("emailVerified", true),

--- a/src/test/scala/com/iscs/ratingbunny/routes/AuthRoutesSuite.scala
+++ b/src/test/scala/com/iscs/ratingbunny/routes/AuthRoutesSuite.scala
@@ -42,9 +42,9 @@ class AuthRoutesSuite extends CatsEffectSuite:
   private val repo = new UserRepo[IO]:
     def findByEmail(email: String): IO[None.type]                    = IO.pure(None)
     def insert(u: UserDoc): IO[Unit]                                 = IO.unit
-    def findByUserId(id: String): IO[Option[UserDoc]]                = IO.pure(if id == user.userid then Some(user) else None)
-    def findByVerificationTokenHash(hash: String): IO[Some[UserDoc]] = IO.pure(Some(unverified))
-    def markEmailVerified(uid: String): IO[Unit]                     = IO.unit
+    def findByUserId(id: String): IO[Option[UserDoc]]               = IO.pure(if id == user.userid then Some(user) else None)
+    def findByVerificationToken(token: String): IO[Option[UserDoc]] = IO.pure(Some(unverified))
+    def markEmailVerified(uid: String): IO[Unit]                    = IO.unit
 
   private val secret    = "test-secret"
   private val authMw    = JwtAuth.middleware[IO](secret)


### PR DESCRIPTION
## Summary
- validate email tokens using hasher.verify rather than rehashing
- add UserRepo method to resolve verification tokens and wire hasher through Server

## Testing
- `sbt test` *(fails: sbt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb9f299908332a41ab7b60e9b5239