### PR TITLE
Persist billing info during pro signup

### DIFF
--- a/src/main/scala/com/iscs/ratingbunny/Server.scala
+++ b/src/main/scala/com/iscs/ratingbunny/Server.scala
@@ -10,6 +10,7 @@ import com.iscs.ratingbunny.domains.{
   AuthCheckImpl,
   AuthLogin,
   AuthLoginImpl,
+  BillingInfo,
   ConnectionPool,
   ConnectionPoolImpl,
   EmailContact,
@@ -63,6 +64,7 @@ object Server:
   private val tbrCollection         = "title_basics_ratings"
   private val usersCollection       = "users"
   private val userProfileCollection = "user_profile"
+  private val billingCollection     = "billing_info"
   private val apiVersion            = "v3"
 
   private val jwtSecretKey =
@@ -72,9 +74,10 @@ object Server:
     for
       userCollCodec     <- db.getCollectionWithCodec[UserDoc](usersCollection)
       userProfCollCodec <- db.getCollectionWithCodec[UserProfileDoc](userProfileCollection)
+      billingCollCodec  <- db.getCollectionWithCodec[BillingInfo](billingCollection)
     yield
       val hasher = BcryptHasher.make[F](cost = 12)
-      new AuthCheckImpl(userCollCodec, userProfCollCodec, hasher, emailService)
+      new AuthCheckImpl(userCollCodec, userProfCollCodec, billingCollCodec, hasher, emailService)
 
   private def getLoginSvc[F[_]: Async](db: MongoDatabase[F], token: TokenIssuer[F]): F[AuthLogin[F]] =
     for userCollCodec <- db.getCollectionWithCodec[UserDoc](usersCollection)

--- a/src/main/scala/com/iscs/ratingbunny/domains/package.scala
+++ b/src/main/scala/com/iscs/ratingbunny/domains/package.scala
@@ -71,11 +71,22 @@ package object domains:
   )
 
   /** -- incoming payload */
+  final case class SignupBilling(
+      gateway: BillingGateway = BillingGateway.Helcim,
+      helcim: HelcimAccount,
+      address: Address,
+      subscription: Option[HelcimSubSnapshot] = None
+  )
+
+  object SignupBilling:
+    given Codec[SignupBilling] = deriveCodec
+
   final case class SignupRequest(
       email: String,
       password: String,
       displayName: Option[String],
-      plan: Plan
+      plan: Plan,
+      billing: Option[SignupBilling] = None
   )
 
   /** --- persisted docs --- */
@@ -196,6 +207,9 @@ package object domains:
       country: String
   )
 
+  object Address:
+    given Codec[Address] = deriveCodec
+
   final case class BillingInfo(
       userId: ObjectId,
       gateway: BillingGateway = BillingGateway.Helcim,
@@ -204,6 +218,9 @@ package object domains:
       subscription: Option[HelcimSubSnapshot] = None,
       updatedAt: Instant = Instant.now()
   )
+
+  object BillingInfo:
+    given Codec[BillingInfo] = deriveCodec
 
   // ---------- request / response ----------
   final case class LoginRequest(email: String, password: String)

--- a/src/main/scala/com/iscs/ratingbunny/routes/AuthRoutes.scala
+++ b/src/main/scala/com/iscs/ratingbunny/routes/AuthRoutes.scala
@@ -80,6 +80,7 @@ object AuthRoutes:
                   case Left(BadCountry)   => BadRequest("Invalid country")
                   case Left(BadLanguage)  => BadRequest("Invalid language")
                   case Left(BadTimezone)  => BadRequest("Invalid time zone")
+                  case Left(BillingRequired) => BadRequest("billing info required for pro plan")
               yield out
         yield resp
       case req @ POST -> Root / "auth" / "login" =>


### PR DESCRIPTION
## Summary
- require billing details when a user selects a paid plan and persist the record in MongoDB
- add codecs for new billing structures and wire the billing collection into the auth service
- extend signup tests to cover billing scenarios and confirm free signups skip billing persistence

## Testing
- unable to run tests: `sbt` is not available in the execution environment


------
https://chatgpt.com/codex/tasks/task_e_68d706462c2883329f72e257e02e0162