### PR TITLE
Ensure signup failures cleanup persisted documents

### DIFF
--- a/src/test/scala/com/iscs/ratingbunny/domains/AuthCheckSpec.scala
+++ b/src/test/scala/com/iscs/ratingbunny/domains/AuthCheckSpec.scala
@@ -163,7 +163,14 @@ class AuthCheckSpec extends CatsEffectSuite with EmbeddedMongo with QuerySetup:
         billingC <- db.getCollectionWithCodec[BillingInfo]("billing_info")
         svc = new AuthCheckImpl[IO](users, prof, billingC, hasher, stubEmailService)
         res <- svc.signup(mkSignup(plan = Plan.ProMonthly))
-      yield assertEquals(res, Left(SignupError.BillingRequired))
+        countU <- users.count
+        countP <- prof.count
+        countB <- billingC.count
+      yield
+        assertEquals(res, Left(SignupError.BillingRequired))
+        assertEquals(countU, 0L)
+        assertEquals(countP, 0L)
+        assertEquals(countB, 0L)
 
   test("pro signup stores billing info"):
     withMongo: db =>


### PR DESCRIPTION
## Summary
- wrap the signup flow in cleanup logic so user, profile, and billing docs are removed on any failure
- centralize error handling and cleanup for signup exceptions
- extend the pro signup spec to assert no documents persist after a billing failure

## Testing
- `sbt test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db58ce381483328054c2b62dc4dde6